### PR TITLE
Add default formatting tests

### DIFF
--- a/bankdomain-values-core/src/test/java/io/github/finoid/bank/domain/BankAccountFormatterUnitTest.java
+++ b/bankdomain-values-core/src/test/java/io/github/finoid/bank/domain/BankAccountFormatterUnitTest.java
@@ -42,6 +42,42 @@ class BankAccountFormatterUnitTest {
         Assertions.assertEquals("9530,364-8748", result);
     }
 
+    @Test
+    void givenSwedbankAccountNumberWithSortingNumber_whenFormatDefault_thenExpectedAccountReturned() {
+        final BankAccountNumber accountNumber = BankAccountNumber.ofString("8129-9,043 386 711-6");
+
+        var result = BankAccountFormatter.format(accountNumber, BankAccountFormatter.Format.DEFAULT);
+
+        Assertions.assertEquals("8129900433867116", result);
+    }
+
+    @Test
+    void givenSwedbankAccountNumber_whenFormatDefault_thenExpectedAccountReturned() {
+        final BankAccountNumber accountNumber = BankAccountNumber.ofString("9340 321 4681");
+
+        var result = BankAccountFormatter.format(accountNumber, BankAccountFormatter.Format.DEFAULT);
+
+        Assertions.assertEquals("9340 00003214681", result);
+    }
+
+    @Test
+    void givenNordeaPersonalNumberAccountNumber_whenFormatDefault_thenExpectedAccountReturned() {
+        final BankAccountNumber accountNumber = BankAccountNumber.ofString("33006001010328");
+
+        var result = BankAccountFormatter.format(accountNumber, BankAccountFormatter.Format.DEFAULT);
+
+        Assertions.assertEquals("3300 06001010328", result);
+    }
+
+    @Test
+    void givenNordeaAccountNumber_whenFormatDefault_thenExpectedAccountReturned() {
+        final BankAccountNumber accountNumber = BankAccountNumber.ofString("95303648748");
+
+        var result = BankAccountFormatter.format(accountNumber, BankAccountFormatter.Format.DEFAULT);
+
+        Assertions.assertEquals("9530 00003648748", result);
+    }
+
     @ParameterizedTest
     @CsvFileSource(resources = "/valid-accounts.csv", delimiter = ';')
     void givenBankAccountNumber_whenOfString_thenExpectedBankAccountNumberReturned(final String accountNumber, final String bankName) {


### PR DESCRIPTION
## Summary
- extend `BankAccountFormatterUnitTest` with tests for `Format.DEFAULT`

## Testing
- `./mvnw -q -pl bankdomain-values-core test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c8d81448328974c4bdf07174a65