### PR TITLE
Fix Type indice handling

### DIFF
--- a/bankdomain-values-maven-plugin/src/main/java/io/github/finoid/bank/domain/maven/plugin/Type.java
+++ b/bankdomain-values-maven-plugin/src/main/java/io/github/finoid/bank/domain/maven/plugin/Type.java
@@ -7,7 +7,7 @@ public enum Type {
     public static Type ofIndice(final int value) {
         final Type[] values = values();
 
-        if (values.length < value) {
+        if (value < 1 || value > values.length) {
             throw new IllegalArgumentException("Invalid indice: " + value);
         }
 

--- a/bankdomain-values-maven-plugin/src/test/java/io/github/finoid/bank/domain/maven/plugin/TypeUnitTest.java
+++ b/bankdomain-values-maven-plugin/src/test/java/io/github/finoid/bank/domain/maven/plugin/TypeUnitTest.java
@@ -1,0 +1,20 @@
+package io.github.finoid.bank.domain.maven.plugin;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TypeUnitTest {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void givenValidIndice_whenOfIndice_thenReturnsExpectedType(int index) {
+        Type expected = Type.values()[index - 1];
+        Assertions.assertEquals(expected, Type.ofIndice(index));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, 5, 6})
+    void givenInvalidIndice_whenOfIndice_thenThrowsIllegalArgumentException(int index) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Type.ofIndice(index));
+    }
+}


### PR DESCRIPTION
## Summary
- validate indice range in `Type.ofIndice`
- test valid and invalid indices

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c8110988328b610b6cbe9f22bef